### PR TITLE
feat: 어드민 유저가 챌린지 승인/삭제 api #73

### DIFF
--- a/api/challengeId.js
+++ b/api/challengeId.js
@@ -8,3 +8,32 @@ export const getChallengeView = async (challengeId) => {
     console.error(e);
   }
 };
+
+export const createChallengeStatus = async (
+  challengeId,
+  state,
+  reason = null
+) => {
+  const body = state === "REJECTED" ? { state, reason } : { state };
+
+  try {
+    const response = await fetch(`${API_URL}/challenge/${challengeId}/status`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || "새로운 상태 요청에 실패했습니다.");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("API 요청 오류:", error);
+    throw error;
+  }
+};

--- a/components/challengeId/AdminArea.js
+++ b/components/challengeId/AdminArea.js
@@ -1,12 +1,10 @@
 import styles from "./AdminArea.module.css";
 
-export default function AdminArea() {
+export default function AdminArea({ setIsOpen, onAccept }) {
   const handleRejectModal = () => {
-    console.log("거절하기");
+    setIsOpen(true);
   };
-  const handleApprove = () => {
-    console.log("승인하기");
-  };
+
   return (
     <div className={styles.adminArea}>
       <button
@@ -16,11 +14,7 @@ export default function AdminArea() {
       >
         거절하기
       </button>
-      <button
-        type="button"
-        className={styles.btnApprove}
-        onClick={handleApprove}
-      >
+      <button type="button" className={styles.btnApprove} onClick={onAccept}>
         승인하기
       </button>
     </div>

--- a/components/challengeId/AdminArea.module.css
+++ b/components/challengeId/AdminArea.module.css
@@ -14,6 +14,7 @@
   height: 48px;
   border: none;
   border-radius: 12px;
+  cursor: pointer;
 }
 .btnReject {
   background: #ffe7e7;

--- a/components/modals/rejectModal.js
+++ b/components/modals/rejectModal.js
@@ -1,13 +1,9 @@
 import Image from "next/image";
 import styles from "./rejectModal.module.css";
 import iconClose from "@/public/icons/ic_close.svg";
-import { rejectChallenge } from "@/mock/myChallengesApply.js";
-import { useRouter } from "next/router";
 import { useState } from "react";
 
-export default function RejectModal() {
-  const router = useRouter();
-  const { id } = router.query;
+export default function RejectModal({ onClose, onReject }) {
   const [reason, setReason] = useState("");
   const [error, setError] = useState("");
 
@@ -19,12 +15,8 @@ export default function RejectModal() {
       return;
     }
 
-    try {
-      const response = await rejectChallenge(id, reason);
-      console.log("거절 완료", response);
-    } catch (error) {
-      console.error("거절 실패", error.message);
-    }
+    onReject(reason);
+    onClose();
   };
 
   return (
@@ -33,7 +25,7 @@ export default function RejectModal() {
       <div className={styles.modalBox}>
         <div className={styles.header}>
           <h3>거절 사유</h3>
-          <button type="button" className={styles.btnIcClose}>
+          <button type="button" className={styles.btnIcClose} onClick={onClose}>
             <Image src={iconClose} width={24} height={24} />
           </button>
         </div>


### PR DESCRIPTION
## #️⃣ Issue Number
#73

## 📝 요약(Summary)

어드민 유저가 챌린지 펜딩상태의 챌린지를 승인/거절하는 기능

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 승인 버튼 -> 승인 상태 생성
- [X] 거절 버튼 -> 거절 모달 -> 거절 사유 입력 -> 거절 상태 + 사유 생성


